### PR TITLE
Populate governance docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Governance for Pyro, NumPyro, and related projects
 
+Pyro is owned by the [LF AI Foundation](https://wiki.lfaidata.foundation/display/PYRO/Pyro+Home).
+
+## Charter
+
+See Pyro's [Technical Charter](https://wiki.lfaidata.foundation/download/attachments/7733298/Pyro%20Project%20Technical%20Charter%201-7-2020.pdf?version=1&modificationDate=1580158662000&api=v2).
+
 ## Code owners
 
 When proposing changes to Pyro projects we recommend cc'ing the following owners.
@@ -24,3 +30,15 @@ For very large design changes we recommend creating a [design document](https://
   @eb8680 and @fritzo
 
 For other repos see git commit history.
+
+## Technical Steering Committee
+
+Pyro development is governed by a the Technical Steering Committee (TSC).
+
+- Eli Bingham (@eb8680)
+- Jonathan P. Chen (@jpchen)
+- Martin Jankowiak (@martinjankowiak)
+- Fritz Obermeyer (@fritzo) - Chair
+- Du Phan (@fehiepsi)
+- Neeraj Pradhan (@neerajprad)
+- Stefan Webb (@stefanwebb)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For other repos see git commit history.
 
 ## Technical Steering Committee
 
-Pyro development is governed by a the Technical Steering Committee (TSC).
+Pyro development is governed by the Technical Steering Committee (TSC).
 
 - Eli Bingham (@eb8680)
 - Jonathan P. Chen (@jpchen)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # Governance for Pyro, NumPyro, and related projects
+
+## Code owners
+
+When proposing changes to Pyro projects we recommend cc'ing the following owners.
+For small changes, feel free to open up a PR directly.
+For large changes we recommend opening a github issue for discussion.
+For very large design changes we recommend creating a [design document](https://github.com/pyro-ppl/pyro/wiki/Design-Docs) for discussion.
+
+- [Pyro](https://github.com/pyro-ppl/pyro) is owned by
+  @fritzo @eb8680 @martinjankowiak @fehiepsi @neerajprad @stefanwebb @jpchen
+  - `pyro.poutine` is mainly owned by @eb8680
+  - `pyro.distributions` is mainly owned by @fritzo and @neerajprad
+  - `pyro.distributions.transforms` is owned by @stefanwebb
+  - `pyro.contrib.gp` is owned by @fehiepsi
+  - `pyro.contrib.forecast` is owned by @fritzo and @martinjankowiak
+  - `pyro.contrib.epidemiology` is owned by @fritzo
+  - `pyro.contrib.funsor` is owned by @eb8680
+
+- [NumPyro](https://github.com/pyro-ppl/numpyro) is owned by
+  @fehiepsi and @neerajprad
+
+- [Funsor](https://github.com/pyro-ppl/funsor) is owned by
+  @eb8680 and @fritzo
+
+For other repos see git commit history.


### PR DESCRIPTION
This is towards our requirements for Pyro graduation

> Document current project owners and current and emeritus committers in OWNERS.md and COMMITTERS.md files; copy of the project’s charter (or other authorized governance document) shall be included or linked to in a GOVERNANCE.md or in a similar file

I have created a new repo so as to put NumPyro on equal level with Pyro; this way NumPyro won't need to point at Pyro for governance docs.